### PR TITLE
Add support for "darwin" (mac)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hasagi/core",
-  "version": "0.5.8",
+  "version": "0.5.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hasagi/core",
-      "version": "0.5.8",
+      "version": "0.5.14",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.7",
@@ -16,7 +16,8 @@
       "devDependencies": {
         "@hasagi/cli": "^0.8.14",
         "@types/ws": "^8.5.10",
-        "prompt": "^1.3.0"
+        "prompt": "^1.3.0",
+        "typescript": "^5.8.3"
       }
     },
     "node_modules/@colors/colors": {
@@ -394,6 +395,20 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
       "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA=="
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/winston": {
       "version": "2.4.7",
@@ -782,6 +797,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
       "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA=="
+    },
+    "typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true
     },
     "winston": {
       "version": "2.4.7",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "devDependencies": {
     "@hasagi/cli": "^0.8.14",
     "@types/ws": "^8.5.10",
-    "prompt": "^1.3.0"
+    "prompt": "^1.3.0",
+    "typescript": "^5.8.3"
   },
   "exports": {
     ".": "./index.js"


### PR DESCRIPTION
This PR basically did 2 things:
- I added support for "darwin" (process method) by adding `/bin/bash` as a shell and changed the process commands accordingly. This works on my machine (a Mac). The other platforms *should* not be impacted by this change...
- Added typescript as a dev dependency because for some reason it wasn't and `tsc` isn't installed by default

I wasn't able to update the types because this library has a ton of circular dependencies (core into cli, cli into core) when it comes to updating those and in the prior versions a Mac wasn't supported just yet...
I tried to adapt the coding style a bit but there wasn't a lot to change so I hope its okay...